### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Real-time Lightning Development Kit (LDK) expertise for accelerating iOS Lightning wallet development. This MCP server provides instant access to LDK APIs, Swift patterns with proper Bindings namespace usage, comprehensive event handling, NetworkGraph with RapidGossipSync, and multiple chain synchronization methods.
 
+<a href="https://glama.ai/mcp/servers/@StevenGeller/ldk-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@StevenGeller/ldk-mcp/badge" alt="LDK Server MCP server" />
+</a>
+
 ## 🚀 Features
 
 ### Lightning Development Tools


### PR DESCRIPTION
This PR adds a badge for the [LDK MCP Server](https://glama.ai/mcp/servers/@StevenGeller/ldk-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@StevenGeller/ldk-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@StevenGeller/ldk-mcp/badge" alt="LDK Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.